### PR TITLE
fixed width of buttons on safari causing buttons to wrap

### DIFF
--- a/src/styles/Calculator.css
+++ b/src/styles/Calculator.css
@@ -46,6 +46,7 @@
 	font-size: 24px;
 	outline: 0;
 	cursor: pointer;
+    width: 24%;
 }
 .calculator section.buttons button:hover{
 	background-color: #ddd;


### PR DESCRIPTION
quick fix to keep buttons from wrapping incorrectly on safari